### PR TITLE
fixes the build of example program in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ You can also access the latest build of the documentation via the internet from 
 Here is a short example on how to create a file and to play it :
 
 ```Rust
-extern crate libc;
 extern crate rfmod;
 
 fn main() {

--- a/README.md
+++ b/README.md
@@ -55,27 +55,25 @@ Here is a short example on how to create a file and to play it :
 extern crate libc;
 extern crate rfmod;
 
-use std::os;
-
 fn main() {
-    let fmod = match rfmod::FmodSys::new() {
+    let fmod = match rfmod::Sys::new() {
         Ok(f) => f,
         Err(e) => {
-            panic!("Error code : {}", e);
+            panic!("Error code : {:?}", e);
         }
     };
 
     match fmod.init() {
         rfmod::Result::Ok => {}
         e => {
-            panic!("FmodSys.init failed : {}", e);
+            panic!("FmodSys.init failed : {:?}", e);
         }
     };
 
-    let mut sound = match fmod.create_sound(StrBuf::from_str("music.mp3"), None, None) {
+    let sound = match fmod.create_sound(&String::from("music.mp3"), None, None) {
         Ok(s) => s,
         Err(err) => {
-            panic!("Error code : {}", err);
+            panic!("Error code : {:?}", err);
         }
     };
 
@@ -84,7 +82,7 @@ fn main() {
             println!("Ok !");
         }
         err => {
-            panic!("Error code : {}", err);
+            panic!("Error code : {:?}", err);
         }
     };
 }

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ fn main() {
         }
     };
 
-    let sound = match fmod.create_sound(&String::from("music.mp3"), None, None) {
+    let sound = match fmod.create_sound("music.mp3", None, None) {
         Ok(s) => s,
         Err(err) => {
             panic!("Error code : {:?}", err);


### PR DESCRIPTION
using rustc 1.4.0, cargo 0.6.0 (e1ed995 2015-10-22), Linux 4.2.5-1-ARCH, there where a bunch of compiler errors and one warning in the example program. this removes them and it seems to run okay.

I don't necessarily know what each of my changes is doing, though.