### PR TITLE
Fix compilation warnings and errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,5 @@ libc = "0.2.6"
 
 [lib]
 name = "rfmod"
+path = "src/rfmod.rs"
 crate-type = ["dylib", "rlib"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fmod"
-version = "0.9.23"
+version = "0.9.24"
 authors = ["Guillaume Gomez <guillaume1.gomez@gmail.com>"]
 
 description = "A rust binding for the FMOD library"

--- a/src/fmod_sys.rs
+++ b/src/fmod_sys.rs
@@ -47,14 +47,14 @@ use c_vec::CVec;
 use std::ffi::CString;
 
 fn get_saved_sys_callback<'r>() -> &'r mut SysCallback {
-    static mut callback : SysCallback = SysCallback {
+    static mut CALLBACK : SysCallback = SysCallback {
             file_open: None,
             file_close: None,
             file_read: None,
             file_seek: None
         };
 
-    unsafe { &mut callback }
+    unsafe { &mut CALLBACK }
 }
 
 struct SysCallback {

--- a/src/rfmod.rs
+++ b/src/rfmod.rs
@@ -98,10 +98,12 @@ For a more complete example : https://github.com/GuillaumeGomez/rust-music-playe
 
 ##License
 
-    Copyright (c) 2014 Guillaume Gomez
+```text
+Copyright (c) 2014 Guillaume Gomez
 
-    The license of this project is available in the LICENSE.TXT file. Please refer to it.
-    If you want more information, here is the website for FMOD : http://www.fmod.org/
+The license of this project is available in the LICENSE.TXT file. Please refer to it.
+If you want more information, here is the website for FMOD : http://www.fmod.org/
+```
 
 #Notes
 


### PR DESCRIPTION
- Fix "implicit path" warning by adding path to [lib] in Cargo.toml
- Fix rustc warning about static variable being in lowercase (made it
uppercase)
- Fix rustdoc formatting in the license section, was causing the
license to be treated as a test when running `$ cargo test`