### PR TITLE
Use from_utf8_lossy() since fmod does not return proper UTF8 in some cases

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -34,9 +34,6 @@ macro_rules! from_utf8 {
             }
         }
         unsafe { $vec.set_len(pos); }
-        match String::from_utf8($vec) {
-            Ok(s) => s,
-            Err(e) => return Err(::RStatus::Other(format!("Invalid utf8: {}", e))),
-        }
+        String::from_utf8_lossy(&$vec).into()
     }}
 }


### PR DESCRIPTION
This is a workaround for #22 

fmod does not return proper UTF-8 on some systems, e.g. when one of the drivers has a German umlaut in their name (e.g. "Kopfhörer"). This PR uses lossy UTF-8 decoding to work around this issue.