### PR TITLE
Fix dangling pointer to create sound exinfo structure

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -837,6 +837,7 @@ pub struct FMOD_DSP_STATE
     pub speaker_mask: c_ushort      /* [w] Specifies which speakers the DSP effect is active on */
 }
 
+#[repr(C)]
 pub struct SoundData {
     pub non_block: SoundNonBlockCallback,
     pub pcm_read: SoundPcmReadCallback,


### PR DESCRIPTION
This should fix issue #25.

Also added `#[repr(C)]` to ffi::SoundData just to be safe since it is
pointed to by the user_data field.